### PR TITLE
Issue #29: Added maven assembly plugin to create executable jarduring…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,28 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>net.sf.javaanpr.jar.Main</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> 
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <dependencies>


### PR DESCRIPTION
… build process. Jar (called javaanpr-jar-with-dependencies) will be created during mvn install. This should fix issue #29 .