### PR TITLE
Made epsilon a constant in TestUtility

### DIFF
--- a/src/test/java/net/sf/javaanpr/configurator/ConfiguratorTest.java
+++ b/src/test/java/net/sf/javaanpr/configurator/ConfiguratorTest.java
@@ -16,6 +16,7 @@
 
 package net.sf.javaanpr.configurator;
 
+import net.sf.javaanpr.test.util.TestUtility;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -64,9 +65,8 @@ public class ConfiguratorTest {
     @Test
     public void testSetAndGetDoublePropertyWithValidDouble() {
         double expectedValue = 5.0;
-        double epsilon = 5.96e-08;
         configurator.setDoubleProperty(propertyName, expectedValue);
-        assertEquals(configurator.getDoubleProperty(propertyName), expectedValue, epsilon);
+        assertEquals(configurator.getDoubleProperty(propertyName), expectedValue, TestUtility.epsilon);
     }
 
     @Test(expected = NumberFormatException.class)

--- a/src/test/java/net/sf/javaanpr/recognizer/RecognizedCharTest.java
+++ b/src/test/java/net/sf/javaanpr/recognizer/RecognizedCharTest.java
@@ -16,6 +16,7 @@
 
 package net.sf.javaanpr.recognizer;
 
+import net.sf.javaanpr.test.util.TestUtility;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -24,7 +25,6 @@ import java.util.Vector;
 import static org.junit.Assert.*;
 
 public class RecognizedCharTest {
-    private static final double epsilon = 5.96e-08;
     private RecognizedChar recognizedChar;
 
     @Before
@@ -41,9 +41,9 @@ public class RecognizedCharTest {
         recognizedChar.sort(false);
         assertTrue(recognizedChar.isSorted());
         Vector<RecognizedPattern> patterns = recognizedChar.getPatterns();
-        assertEquals(patterns.get(0).getCost(), 1.0f, epsilon);
-        assertEquals(patterns.get(1).getCost(), 3.0f, epsilon);
-        assertEquals(patterns.get(2).getCost(), 4.0f, epsilon);
+        assertEquals(patterns.get(0).getCost(), 1.0f, TestUtility.epsilon);
+        assertEquals(patterns.get(1).getCost(), 3.0f, TestUtility.epsilon);
+        assertEquals(patterns.get(2).getCost(), 4.0f, TestUtility.epsilon);
     }
 
     @Test
@@ -52,15 +52,15 @@ public class RecognizedCharTest {
         recognizedChar.sort(true);
         assertTrue(recognizedChar.isSorted());
         Vector<RecognizedPattern> patterns = recognizedChar.getPatterns();
-        assertEquals(patterns.get(0).getCost(), 4.0f, epsilon);
-        assertEquals(patterns.get(1).getCost(), 3.0f, epsilon);
-        assertEquals(patterns.get(2).getCost(), 1.0f, epsilon);
+        assertEquals(patterns.get(0).getCost(), 4.0f, TestUtility.epsilon);
+        assertEquals(patterns.get(1).getCost(), 3.0f, TestUtility.epsilon);
+        assertEquals(patterns.get(2).getCost(), 1.0f, TestUtility.epsilon);
     }
 
     @Test
     public void testGetPatternReturnsCorrectPatternWhenPatternsSorted() {
         recognizedChar.sort(false);
-        assertEquals(recognizedChar.getPattern(2).getCost(), 4.0f, epsilon);
+        assertEquals(recognizedChar.getPattern(2).getCost(), 4.0f, TestUtility.epsilon);
     }
 
     @Test

--- a/src/test/java/net/sf/javaanpr/test/util/TestUtility.java
+++ b/src/test/java/net/sf/javaanpr/test/util/TestUtility.java
@@ -24,6 +24,7 @@ import java.io.IOException;
  * Utility class which helps in having methods for Testing.
  */
 public class TestUtility {
+    public static final double epsilon = 5.96e-08;
 
     public StringBuilder readFile(final String filename) throws IOException {
         final BufferedReader br = new BufferedReader(new FileReader(filename));


### PR DESCRIPTION
Made epsilon a constant in TestUtility so that it can be used in tests to compare doubles. This was brought up as an issue in pull request #34 .