### PR TITLE
Added Canadian license plates format

### DIFF
--- a/src/main/resources/syntax.xml
+++ b/src/main/resources/syntax.xml
@@ -65,4 +65,85 @@
         <char content="o0123456789"/>
         <char content="o0123456789"/>
     </type>
+
+    <!-- source https://en.wikipedia.org/wiki/Canadian_licence_plate_designs_and_serial_formats -->
+    <type name="canada_ab">
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+    </type>
+    <type name="canada_bc">
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+    </type>
+    <type name="canada_nb_nf_ns">
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+    </type>
+    <type name="canada_nwt_nv">
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+    </type>
+    <type name="canada_on">
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+    </type>
+    <type name="canada_pe">
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+    </type>
+    <type name="canada_qc">
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+    </type>
+    <type name="canada_sk">
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+    </type>
+    <type name="canada_yk">
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="abcdefghijklmno0pqrstuvwxyz"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+    </type>
+    <type name="canada_dnd">
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+        <char content="0123456789"/>
+    </type>
 </structure>


### PR DESCRIPTION
This is some progress for #86.

The Canadian license plates change from province to province. Included here are only private vehicles (commercial vehicles have different formats).

Most provinces have a space in the format (e.g., ABC 123). This might be a worthy extension for the syntax.xml format in some moment.

I can add some new test cases for Canadian plates if you want, but the plates in Canada have plenty of decoration and mottos, etc. I'm not sure how well the current codebase will react to that.
